### PR TITLE
Maintainance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,13 @@
+name: "Test"
+on:
+  pull_request:
+  push:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - uses: cachix/install-nix-action@v16
+      with:
+        nix_path: nixpkgs=channel:nixos-22.05:nixpkgs-overlays=./overlays
+    - run: nix-shell -p home-manager --command "home-manager build -f home.nix"

--- a/home/development/haskell.nix
+++ b/home/development/haskell.nix
@@ -10,6 +10,7 @@ in
       stylish-haskell
       haskell-language-server
       gmp
+      cabal2nix
     ];
 
     sessionPath = [

--- a/overlays/biscuit-haskell.nix
+++ b/overlays/biscuit-haskell.nix
@@ -1,0 +1,14 @@
+self: super:
+  {
+    haskell = super.haskell // {
+      packages = super.haskell.packages // {
+        ghc902 = super.haskell.packages.ghc902.override {
+          overrides = self: super: {
+            biscuit-haskell = self.callPackage biscuit-haskell/package.nix {};
+            biscuit-haskell-candidate = self.callPackage biscuit-haskell/candidate.nix {};
+            biscuit-haskell-original  = self.callPackage biscuit-haskell/original.nix  {};
+          };
+        };
+      };
+    };
+  }

--- a/overlays/biscuit-haskell/candidate.nix
+++ b/overlays/biscuit-haskell/candidate.nix
@@ -1,0 +1,31 @@
+{ mkDerivation, aeson, async, attoparsec, base, base16-bytestring
+, base64, bytestring, cereal, containers, criterion, cryptonite
+, fetchzip, lens, lens-aeson, lib, memory, mtl, parser-combinators
+, protobuf, random, regex-tdfa, tasty, tasty-hunit
+, template-haskell, text, th-lift-instances, time
+, validation-selective
+}:
+mkDerivation {
+  pname = "biscuit-haskell";
+  version = "0.2.1.0";
+  src = fetchzip {
+    url = "https://frederic.menou.me/biscuit-haskell-0.2.1.0.tar.gz";
+    sha256 = "0izh7bmg5zr2j8vp0clzyd2bgc41zq54i3scl3cjvimx74fh3lq0";
+  };
+  libraryHaskellDepends = [
+    async attoparsec base base16-bytestring base64 bytestring cereal
+    containers cryptonite memory mtl parser-combinators protobuf random
+    regex-tdfa template-haskell text th-lift-instances time
+    validation-selective
+  ];
+  testHaskellDepends = [
+    aeson async attoparsec base base16-bytestring base64 bytestring
+    cereal containers cryptonite lens lens-aeson mtl parser-combinators
+    protobuf random tasty tasty-hunit template-haskell text
+    th-lift-instances time validation-selective
+  ];
+  benchmarkHaskellDepends = [ base criterion ];
+  homepage = "https://github.com/biscuit-auth/biscuit-haskell#readme";
+  description = "Library support for the Biscuit security token";
+  license = lib.licenses.bsd3;
+}

--- a/overlays/biscuit-haskell/original.nix
+++ b/overlays/biscuit-haskell/original.nix
@@ -1,0 +1,31 @@
+{ mkDerivation, aeson, async, attoparsec, base, base16-bytestring
+, base64, bytestring, cereal, containers, criterion, cryptonite
+, fetchzip, lens, lens-aeson, lib, memory, mtl, parser-combinators
+, protobuf, random, regex-tdfa, tasty, tasty-hunit
+, template-haskell, text, th-lift-instances, time
+, validation-selective
+}:
+mkDerivation {
+  pname = "biscuit-haskell";
+  version = "0.2.1.0";
+  src = fetchzip {
+    url = "https://frederic.menou.me/biscuit-haskell-original.tar.gz";
+    sha256 = "18p8xx81j9bw2hs4ry04x5c52r1vdxv6agd2zj8y00kcszalgn2s";
+  };
+  libraryHaskellDepends = [
+    async attoparsec base base16-bytestring base64 bytestring cereal
+    containers cryptonite memory mtl parser-combinators protobuf random
+    regex-tdfa template-haskell text th-lift-instances time
+    validation-selective
+  ];
+  testHaskellDepends = [
+    aeson async attoparsec base base16-bytestring base64 bytestring
+    cereal containers cryptonite lens lens-aeson mtl parser-combinators
+    protobuf random tasty tasty-hunit template-haskell text
+    th-lift-instances time validation-selective
+  ];
+  benchmarkHaskellDepends = [ base criterion ];
+  homepage = "https://github.com/biscuit-auth/biscuit-haskell#readme";
+  description = "Library support for the Biscuit security token";
+  license = lib.licenses.bsd3;
+}

--- a/overlays/biscuit-haskell/package.nix
+++ b/overlays/biscuit-haskell/package.nix
@@ -1,0 +1,33 @@
+{ mkDerivation, aeson, async, attoparsec, base, base16-bytestring
+, base64, bytestring, cereal, containers, criterion, cryptonite
+, directory, fetchzip, filepath, lens, lens-aeson, lib, memory, mtl
+, parser-combinators, protobuf, random, regex-tdfa, tasty
+, tasty-hunit, template-haskell, text, th-lift-instances, time
+, validation-selective
+}:
+mkDerivation {
+  pname = "biscuit-haskell";
+  version = "0.2.1.0";
+  src = fetchzip {
+    url = "https://github.com/ptitfred/biscuit-haskell/archive/refs/heads/fix-nixpkgs.zip";
+    sha256 = "k+som/AG1U2YNRF/CauDZPd9ufPwwrWOgjCHRZTo98I="; # "1hppx2a4b1rhha7bbhphyfwpvxv4hfmhjzqi6nc4vm86y2djiswk";
+  };
+  postUnpack = "sourceRoot+=/biscuit; echo source root reset to $sourceRoot";
+  enableSeparateDataOutput = true;
+  libraryHaskellDepends = [
+    async attoparsec base base16-bytestring base64 bytestring cereal
+    containers cryptonite memory mtl parser-combinators protobuf random
+    regex-tdfa template-haskell text th-lift-instances time
+    validation-selective
+  ];
+  testHaskellDepends = [
+    aeson async attoparsec base base16-bytestring base64 bytestring
+    cereal containers cryptonite directory filepath lens lens-aeson mtl
+    parser-combinators protobuf random tasty tasty-hunit
+    template-haskell text th-lift-instances time validation-selective
+  ];
+  benchmarkHaskellDepends = [ base criterion ];
+  homepage = "https://github.com/biscuit-auth/biscuit-haskell#readme";
+  description = "Library support for the Biscuit security token";
+  license = lib.licenses.bsd3;
+}

--- a/overlays/personal.nix
+++ b/overlays/personal.nix
@@ -6,6 +6,5 @@ in
     in
       {
         posix-toolbox = fetchPackage self ./ptitfred-posix-toolbox.json "/nix/default.nix";
-        inherit (fetchPackage self ./synthetica9-nix-linter.json "/default.nix") nix-linter;
         inherit postgresql_12_postgis;
       }

--- a/overlays/synthetica9-nix-linter.json
+++ b/overlays/synthetica9-nix-linter.json
@@ -1,7 +1,0 @@
-{
-    "owner": "Synthetica9",
-    "repo": "nix-linter",
-    "rev": "2516a8cda41f9bb553a1c3eca38e3dd94ebf53de",
-    "sha256": "07mn2c9v67wsm57jlxv9pqac9hahw4618vngmj2sfbgihx8997kb",
-    "fetchSubmodules": true
-}


### PR DESCRIPTION
- **nix-linter from nixpkgs is fine now**
  "now" being stable 22.05
- **Haskell: provide cabal2nix**
  It's a common tool required for most haskell projects and not to be provided by each one of them (especially for projects not aware of Nix).
- **Overlay for biscuit-haskell**
  Overlay is required until hydra builds it and it's not tagged as "failing" anymore.
  It won't be necessary once a proper release including https://github.com/biscuit-auth/biscuit-haskell/pull/49 is made.

As a bonus, there's now CI over the whole configuration and overlays.