### PR TITLE
Fork of haddocset to support ghc-9.0.2

### DIFF
--- a/overlays/personal.nix
+++ b/overlays/personal.nix
@@ -6,5 +6,6 @@ in
     in
       {
         posix-toolbox = fetchPackage self ./ptitfred-posix-toolbox.json "/nix/default.nix";
+        haddocset = fetchPackage self ./ptitfred-haddocset.json "/default.nix";
         inherit postgresql_12_postgis;
       }

--- a/overlays/ptitfred-haddocset.json
+++ b/overlays/ptitfred-haddocset.json
@@ -1,0 +1,7 @@
+{
+    "owner": "ptitfred",
+    "repo": "haddocset",
+    "rev": "371cc353b7863a2c00d8f20ad916f31997d9f97c",
+    "sha256": "VrNpfJXGlbzM3T8Pa/AQLdCMjWO4l2CHw16KO4c63aU=",
+    "fetchSubmodules": false
+}


### PR DESCRIPTION
It's basically pointing at https://github.com/ptitfred/haddocset/tree/bump-lts-19.