### PR TITLE
Adjust opacity rules for Firefox & Zeal

### DIFF
--- a/home/desktop.nix
+++ b/home/desktop.nix
@@ -168,7 +168,7 @@ in
           blur = false;
           inactiveOpacity = "0.93";
           menuOpacity = "0.95";
-          opacityRule = [ "100:name *= 'i3lock'" "100:class_g = 'Firefox'"];
+          opacityRule = [ "100:name *= 'i3lock'" "100:class_g *= 'firefox'" "100:class_g *= 'Zeal'"];
           vSync = false;
         };
 


### PR DESCRIPTION
Both are displaying web pages and I don't want opacity when displaying rich content.

It was supposed to do it for Firefox already but looks like configuration bitrot.