### PR TITLE
Minor improvements

### DIFF
--- a/home/desktop.nix
+++ b/home/desktop.nix
@@ -194,7 +194,7 @@ in
           inherit (config.desktop.location) latitude longitude;
         };
 
-        screen-locker = {
+        screen-locker = lib.mkIf (! (config.desktop.virtual-machine)) {
           enable = true;
           inactiveInterval = 120;
           inherit lockCmd;

--- a/home/home-manager.nix
+++ b/home/home-manager.nix
@@ -1,8 +1,6 @@
 { ... }:
 
 {
-  programs.home-manager.enable = true;
-
   home.stateVersion = "18.09";
 
   news.display = "silent";


### PR DESCRIPTION
- [Screenlocker: disable if in VM](https://github.com/ptitfred/nixos-configuration/pull/20/commits/24e2cbd4aaedfb13657676a4094d7a291eb53820)
  The host is responsible of screen locking.
- [home-manager is considered as provided](https://github.com/ptitfred/nixos-configuration/pull/20/commits/3888daa5f029b225e7284b80294f22febc329318)
  The system is responsible of providing it.